### PR TITLE
Add k8s & gcp resource attributes to metrics

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -87,3 +87,22 @@ vars:
 #    kind: Service
 #    version: v1
 #    name: webhook-service
+
+replacements:
+# Specify a unique label for deployment pods.
+# This enables use of kubectl logs with a deployment selector.
+# The label is also used by the downward API to inject the deployment name as an
+# env var for use as a metrics resource attribute.
+- source:
+    kind: Deployment
+    name: controller-manager
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Deployment
+      name: controller-manager
+    fieldPaths:
+    - spec.selector.matchLabels.configsync\.gke\.io/deployment-name
+    - spec.template.metadata.labels.configsync\.gke\.io/deployment-name
+    options:
+      create: true

--- a/config/default/manager_otel_agent.yaml
+++ b/config/default/manager_otel_agent.yaml
@@ -16,16 +16,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager # value replaced by kustomize
   namespace: system
 spec:
+  selector:
+    matchLabels:
+      configsync.gke.io/deployment-name: controller-manager # value replaced by kustomize
   template:
+    metadata:
+      labels:
+        configsync.gke.io/deployment-name: controller-manager # value replaced by kustomize
     spec:
       containers:
       - name: manager
         args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
+        # The OC_RESOURCE_LABELS env var configures container-specific resource
+        # attributes for the OpenCensus metrics exporter.
+        env:
+        - name: OC_RESOURCE_LABELS
+          value: 'k8s.container.name="manager"'
       - name: otel-agent
         image: gcr.io/config-management-release/otelcontribcol:v0.54.0
         command:
@@ -55,6 +66,48 @@ spec:
           runAsUser: 1000
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        # These KUBE env vars help populate OTEL_RESOURCE_ATTRIBUTES which
+        # is used by the otel-agent to populate resource attributes when
+        # emiting metrics to the otel-collector. This is more efficient than
+        # having the otel-collector look them up from the apiserver.
+        env:
+        - name: KUBE_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: KUBE_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBE_POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: KUBE_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: KUBE_DEPLOYMENT_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['configsync.gke.io/deployment-name']
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "k8s.pod.name=$(KUBE_POD_NAME),\
+            k8s.pod.namespace=$(KUBE_POD_NAMESPACE),\
+            k8s.pod.uid=$(KUBE_POD_UID),\
+            k8s.pod.ip=$(KUBE_POD_IP),\
+            k8s.node.name=$(KUBE_NODE_NAME),\
+            k8s.deployment.name=$(KUBE_DEPLOYMENT_NAME)"
       volumes:
       - name: otel-agent-config-vol
         configMap:

--- a/config/opentelemetry/otel_config.yaml
+++ b/config/opentelemetry/otel_config.yaml
@@ -33,6 +33,10 @@ data:
           insecure: true
     processors:
       batch:
+      # Populate resource attributes from OTEL_RESOURCE_ATTRIBUTES env var and
+      # the GCE metadata service, if available.
+      resourcedetection:
+        detectors: [env, gcp]
     extensions:
       health_check:
     service:
@@ -40,5 +44,5 @@ data:
       pipelines:
         metrics:
           receivers: [opencensus]
-          processors: [batch]
+          processors: [batch, resourcedetection]
           exporters: [opencensus]

--- a/controllers/metrics/register.go
+++ b/controllers/metrics/register.go
@@ -15,26 +15,12 @@
 package metrics
 
 import (
-	"os"
-
 	"contrib.go.opencensus.io/exporter/ocagent"
 	"go.opencensus.io/stats/view"
 )
 
-const (
-	resourceGroupSystemNamespace = "resource-group-system"
-	resourceGroupDeploymentName  = "resource-group-controller-manager"
-)
-
 // RegisterOCAgentExporter creates the OC Agent metrics exporter.
 func RegisterOCAgentExporter() (*ocagent.Exporter, error) {
-	err := os.Setenv(
-		"OC_RESOURCE_LABELS",
-		"k8s.namespace.name=\""+resourceGroupSystemNamespace+"\",k8s.pod.name=\""+resourceGroupDeploymentName+"\"")
-	if err != nil {
-		return nil, err
-	}
-
 	oce, err := ocagent.NewExporter(
 		ocagent.WithInsecure(),
 	)

--- a/controllers/metrics/tagkeys.go
+++ b/controllers/metrics/tagkeys.go
@@ -39,4 +39,9 @@ var (
 
 	// KeyComponent groups metrics by their component. Possible value: readiness
 	KeyComponent, _ = tag.NewKey("component")
+
+	// ResourceKeyDeploymentName groups metrics by k8s deployment name.
+	// This metric tag is populated from the k8s.deployment.name resource
+	// attribute for Prometheus using the resource_to_telemetry_conversion feature.
+	ResourceKeyDeploymentName, _ = tag.NewKey("k8s_deployment_name")
 )


### PR DESCRIPTION
- The following resource attributes were added to all metrics from the resource-group-controller-manager:
  - k8s.container.name
  - k8s.pod.name
  - k8s.pod.namespace
  - k8s.pod.uid
  - k8s.pod.ip
  - k8s.node.name
  - k8s.deployment.name
- The above resource attributes are injected via the OTEL_RESOURCE_ATTRIBUTES env var in the Deployment yaml for the otel-agent container.
- The following labels are used to inject resource attribute values:
  - configsync.gke.io/deployment-name
- The following env vars are use to inject values from the k8s downward API into resource attribute values:
  - KUBE_POD_NAME
  - KUBE_POD_NAMESPACE
  - KUBE_POD_UID
  - KUBE_POD_IP
  - KUBE_NODE_NAME
  - KUBE_DEPLOYMENT_NAME
- The OC_RESOURCE_LABELS env var is used to inject the k8s.container.name resource attribute into the OpenCensus exporter
- Enable the GCP resource processor on the opentelemetry agent. This adds the following resource attributes:
  - cloud.provider
  - cloud.platform
  - cloud.account.id
  - cloud.region OR cloud.availability_zone
  - host.id
  - host.name (when not using workload identity)
- When then GCE metadata server is unavailable, the resource processor exits without modifying the resource attributes. So it's safe to enable globally.
- Enabling the resource processor on the agent sidecars allows for more accurate attributes, like the host.id of the node the reconciler is on, instead of the host.id of the otel-collector.

For more details, see the docs:
https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor

e2e tests will come in a separate follow up PR, because it requires enabling resource_to_telemetry_conversion to make the resource attributes testable in Prometheus. 