### PR TITLE
Fix contribution guidelines link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ status.
 ## Contributing
 
 If you are interested in contributing please start with
-[contribution guidelines](docs/CONTRIBUTING.md).
+[contribution guidelines](docs/contributing.md).
 
 ## Local Development
 


### PR DESCRIPTION
This change fixes the contribution guidelines link on the README to link to the correct page. Following the link today returns a 404 Not Found error.