### PR TITLE
Exclude creation timestamp from resources when generating manifest

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -25,6 +25,7 @@ commonLabels:
   configmanagement.gke.io/system: "true"
 
 patchesStrategicMerge:
+- patches/crd_delete_creation_timestamp.yaml
 - patches/crd_preserveunknownfields_false.yaml
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD

--- a/config/crd/patches/crd_delete_creation_timestamp.yaml
+++ b/config/crd/patches/crd_delete_creation_timestamp.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- op: add
-  path: /rules/-
-  value:
-    apiGroups:
-    - policy
-    resources:
-    - podsecuritypolicies
-    resourceNames:
-    - acm-psp
-    verbs:
-    - use
-- op: add
-  path: /metadata/labels
-  value:
-    configmanagement.gke.io/system: "true"
-- op: remove
-  path: /metadata/creationTimestamp
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcegroups.kpt.dev
+  creationTimestamp:
+    $patch: delete
+spec:
+  preserveUnknownFields: false


### PR DESCRIPTION
This change updates the Kustomize rules to exclude the metadata creationTimestamp field when creating the resource group manifest. This field is set by Kubernetes when resources are created on the cluster so there's no need to include this field in the manifest.